### PR TITLE
Start and end game screen

### DIFF
--- a/public/canvas.js
+++ b/public/canvas.js
@@ -1,11 +1,11 @@
-// V1 TODOs
-// Lastly alles pushen, README mit kleinem screenshot, in portfolio adden und portfolio project noch private machen
-
 import { DINO_SPRITE_WALK_CYCLE } from "./entities/dino.js ";
 
 import { collisionCheck } from "./helpers.js";
 import { Dino } from "./entities/dino.js";
 import { Cactus } from "./entities/cactus.js";
+import { CANVAS_HEIGHT, CANVAS_WIDTH } from "./constants.js";
+
+let gameState = "start"; // Possible values: 'start', 'playing', 'gameOver'
 
 // Get the canvas element and its context
 const canvas = document.getElementById("gameCanvas");
@@ -24,14 +24,38 @@ let frame;
 
 function animate() {
   if (ctx) {
-    // find next sprite
+    if (gameState == "start") {
+      ctx.font = "24px Arial";
+      ctx.fillText(
+        "Press any button to start!",
+        CANVAS_WIDTH / 2 - 130,
+        CANVAS_HEIGHT / 2 - 100
+      );
+    }
+    if (gameState == "gameOver") {
+      ctx.fillStyle = "black";
+      ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+      ctx.fillStyle = "white";
+      ctx.font = "48px Arial";
+      ctx.fillText("Game Over", CANVAS_WIDTH / 2 - 125, CANVAS_HEIGHT / 2);
+      ctx.font = "24px Arial";
+      ctx.fillText(
+        "Press any button to try again!",
+        CANVAS_WIDTH / 2 - 160,
+        CANVAS_HEIGHT / 2 + 50
+      );
+      return; // Stop rendering
+    }
     if (frameIndex === DINO_SPRITE_WALK_CYCLE.length) {
+      // find next sprite
       frameIndex = 0;
     }
     frame = DINO_SPRITE_WALK_CYCLE[frameIndex];
 
-    // clear canvas
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    // clear canvas on every frame when playing
+    if (gameState == "playing") {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+    }
 
     // draw dino
     ctx.drawImage(
@@ -60,12 +84,14 @@ function animate() {
     );
 
     // Update entities and sprites
-    frameIndex += 1;
-    Dino.update();
-    Cactus.update();
+    if (gameState == "playing") {
+      frameIndex += 1;
+      Dino.update();
+      Cactus.update();
+    }
 
     if (collisionCheck(Dino, Cactus)) {
-      alert("Game over!");
+      gameState = "gameOver";
     }
   }
 }
@@ -77,6 +103,20 @@ dinoImage.onload = function () {
 
 // Dino jump event listener
 document.addEventListener("keydown", () => {
+  if (gameState == "gameOver") {
+    Dino.reset();
+    Cactus.reset();
+    gameState = "start";
+    setTimeout(function () {
+      Dino.isJumping = false;
+    });
+  }
+  if (gameState == "start") {
+    gameState = "playing";
+    setTimeout(function () {
+      Dino.isJumping = false;
+    });
+  }
   Dino.isJumping = true;
   setTimeout(function () {
     Dino.isJumping = false;

--- a/public/entities/cactus.js
+++ b/public/entities/cactus.js
@@ -1,5 +1,7 @@
 import { CANVAS_WIDTH, CANVAS_HEIGHT } from "../constants.js";
 
+const CACTUS_DEFAULT_X = CANVAS_WIDTH - 20;
+const CACTUS_DEFAULT_Y = CANVAS_HEIGHT - 30;
 export const Cactus = {
   x: CANVAS_WIDTH - 20,
   y: CANVAS_HEIGHT - 30,
@@ -18,5 +20,10 @@ export const Cactus = {
   draw(ctx) {
     // Draw Cactus on the canvas
     // ...
+  },
+
+  reset() {
+    this.x = CACTUS_DEFAULT_X;
+    this.y = CACTUS_DEFAULT_Y;
   },
 };

--- a/public/entities/dino.js
+++ b/public/entities/dino.js
@@ -13,7 +13,7 @@ export const DINO_SPRITE_WALK_CYCLE = [3, 4, 5, 6, 7, 8].map(
 
 export const Dino = {
   x: 0,
-  y: RUNNING_HEIGHT, // TODO: Update in update instead, checking isJumping there
+  y: RUNNING_HEIGHT,
   spriteWidth: DINO_SPRITE_DIM,
   spriteHeight: DINO_SPRITE_DIM,
   renderWidth: DINO_RENDER_DIM,
@@ -32,5 +32,10 @@ export const Dino = {
   draw(ctx) {
     // Draw Dino on the canvas
     // ...
+  },
+
+  reset() {
+    this.y = RUNNING_HEIGHT;
+    this.isJumping = false;
   },
 };


### PR DESCRIPTION
Before game start:

![Screenshot 2024-01-09 at 15 12 10](https://github.com/georgboehm/AudioDino/assets/40793613/f643ed4b-952a-4a6b-810a-b176c9ab45cc)

After game is lost:

![Screenshot 2024-01-09 at 15 12 53](https://github.com/georgboehm/AudioDino/assets/40793613/b2773f0a-216a-4828-b7e4-279ae591e7a9)

Upcoming after this PR:

- Manage gameState in a more proper way as well as keydown event listener
- Add score that is being kept track of