### PR TITLE
add score

### DIFF
--- a/public/animate.js
+++ b/public/animate.js
@@ -1,4 +1,4 @@
-import { collisionCheck } from "./helpers.js";
+import { collisionCheck, jumpOverCactusSuccessful } from "./helpers.js";
 import Dino, {
   DINO_RENDER_DIM,
   DINO_SPRITE_DIM,
@@ -38,7 +38,7 @@ const cactus = new Cactus(
   CACTUS_RENDER_HEIGHT
 );
 
-const game = new Game(gameStates.START, ctx, dino, cactus);
+const game = new Game(gameStates.START, ctx, dino, cactus, 0);
 
 // Animation loop
 function animate() {
@@ -48,6 +48,11 @@ function animate() {
     // Check for collision between entities
     if (collisionCheck(dino, cactus)) {
       game.setGameState(gameStates.GAME_OVER);
+    }
+
+    // Check for score increase
+    if (jumpOverCactusSuccessful(dino, cactus)) {
+      game.increaseScore();
     }
   }
 }

--- a/public/constants.js
+++ b/public/constants.js
@@ -1,2 +1,3 @@
 export const CANVAS_WIDTH = 600;
 export const CANVAS_HEIGHT = 600;
+export const NECESSARY_HIGHSCORE_FOR_LINK = 1;

--- a/public/drawUtils.js
+++ b/public/drawUtils.js
@@ -1,4 +1,6 @@
 import { CANVAS_HEIGHT, CANVAS_WIDTH } from "./constants.js";
+import { NECESSARY_HIGHSCORE_FOR_LINK } from "./constants.js";
+import { toggleAudioDownloadLinkVisibility } from "./helpers.js";
 
 export function drawStartScreen(context) {
   context.font = "24px Arial";
@@ -9,16 +11,35 @@ export function drawStartScreen(context) {
   );
 }
 
-export function clearCanvas(context) {
+export function drawPlayingScreen(context, score) {
   context.clearRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+  context.fillStyle = "black";
+  context.font = "20px Arial";
+  context.fillText(`Score: ${score}`, 25, 30);
 }
 
-export function drawGameOverScreen(context) {
+export function drawGameOverScreen(context, score) {
+  let displayText;
+  let displayTextX;
+  if (score >= NECESSARY_HIGHSCORE_FOR_LINK) {
+    toggleAudioDownloadLinkVisibility(true);
+    displayText = "Track unlocked!";
+    displayTextX = CANVAS_WIDTH / 2 - 165;
+  } else {
+    displayText = "Game Over";
+    displayTextX = CANVAS_WIDTH / 2 - 125;
+  }
   context.fillStyle = "black";
   context.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
   context.fillStyle = "white";
   context.font = "48px Arial";
-  context.fillText("Game Over", CANVAS_WIDTH / 2 - 125, CANVAS_HEIGHT / 2);
+  context.fillText(displayText, displayTextX, CANVAS_HEIGHT / 2 - 50);
+  context.font = "24px Arial";
+  context.fillText(
+    `Final score: ${score}`,
+    CANVAS_WIDTH / 2 - 75,
+    CANVAS_HEIGHT / 2
+  );
   context.font = "24px Arial";
   context.fillText(
     "Press any button to try again!",

--- a/public/entities/cactus.js
+++ b/public/entities/cactus.js
@@ -30,7 +30,7 @@ class Cactus extends Entity {
     if (this.x <= 0) {
       this.x = CANVAS_WIDTH - 20;
     }
-    this.x = this.x - 10;
+    this.x = this.x - 20;
   }
 
   reset() {

--- a/public/game.js
+++ b/public/game.js
@@ -1,8 +1,10 @@
 import {
   drawStartScreen,
-  clearCanvas,
+  drawPlayingScreen,
   drawGameOverScreen,
 } from "./drawUtils.js";
+import { toggleAudioDownloadLinkVisibility } from "./helpers.js";
+
 export const gameStates = {
   START: 0,
   PLAYING: 1,
@@ -10,24 +12,26 @@ export const gameStates = {
 };
 
 class Game {
-  constructor(gameState, context, dino, cactus) {
+  constructor(gameState, context, dino, cactus, score) {
     this.gameState = gameState;
     this.context = context;
     this.dino = dino;
     this.cactus = cactus;
     this.entities = [dino, cactus];
+    this.score = score;
   }
 
   // Draw canvas and entities and update states
   update() {
     switch (this.gameState) {
       case gameStates.PLAYING:
-        clearCanvas(this.context);
+        drawPlayingScreen(this.context, this.score);
         this.entities.forEach((entity) => entity.draw(this.context));
         this.entities.forEach((entity) => entity.update());
         break;
       case gameStates.GAME_OVER:
-        drawGameOverScreen(this.context);
+        drawGameOverScreen(this.context, this.score);
+        // Check for download link highscore
         this.entities.forEach((entity) => entity.reset());
         break;
       default:
@@ -43,7 +47,7 @@ class Game {
       this.dino.isJumping = true;
       setTimeout(() => {
         this.dino.isJumping = false;
-      }, 1000);
+      }, 2000);
     }
     // Key was pressed to start new game
     if (
@@ -51,14 +55,24 @@ class Game {
       this.gameState == gameStates.GAME_OVER
     ) {
       this.setGameState(gameStates.PLAYING);
+      this.reset();
       setTimeout(() => {
         this.dino.isJumping = false;
       }, 100);
     }
   }
 
+  increaseScore() {
+    this.score = this.score + 1;
+  }
+
   setGameState(state) {
     this.gameState = state;
+  }
+
+  reset() {
+    this.score = 0;
+    toggleAudioDownloadLinkVisibility(false);
   }
 }
 

--- a/public/helpers.js
+++ b/public/helpers.js
@@ -8,7 +8,7 @@ function spritePositionToImagePosition(col) {
   };
 }
 
-// Checks for collision between player and obstacles
+// Checks for collision between dino and cactus
 function collisionCheck(dino, cactus) {
   return (
     dino.x + DINO_RENDER_DIM - 20 > cactus.x &&
@@ -16,4 +16,21 @@ function collisionCheck(dino, cactus) {
   );
 }
 
-export { spritePositionToImagePosition, collisionCheck };
+// Checks if dino jumped over cactus successfully
+// and increases score accordingly
+function jumpOverCactusSuccessful(dino, cactus) {
+  return cactus.x <= dino.x;
+}
+
+// Function to toggle linkDiv visibility
+function toggleAudioDownloadLinkVisibility(showLink) {
+  const linkDiv = document.getElementById("linkDiv");
+  linkDiv.style.display = showLink ? "block" : "none";
+}
+
+export {
+  spritePositionToImagePosition,
+  collisionCheck,
+  jumpOverCactusSuccessful,
+  toggleAudioDownloadLinkVisibility,
+};

--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,9 @@
     <div id="content">
       <h1>Audio Dino on tour</h1>
       <canvas id="gameCanvas" width="600" height="600"></canvas>
+      <div id="linkDiv">
+        <a href="https://www.example.com" target="_blank">Download new track</a>
+      </div>
     </div>
     <script type="module" src="animate.js"></script>
   </body>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,10 +1,12 @@
 #content {
   text-align: center;
-  margin-top: 50px; /* Optional: Add some top margin for better appearance */
+  margin-top: 50px;
 }
 
 #gameCanvas {
-  border: 2px solid black; /* Adds a 2px black border around the canvas */
+  border: 2px solid black;
 }
 
-/* Optional: Add any additional styling as needed */
+#linkDiv {
+  display: none;
+}


### PR DESCRIPTION
Track download link only displays upon reaching necessary highscore only leads to example.com for now.
Score resets on game reset.
Necessary score tracked via constant.

![Screenshot 2024-01-10 at 12 16 53](https://github.com/georgboehm/AudioDino/assets/40793613/1bfd4418-1347-47f5-94f1-b7bb18fd46b6)
![Screenshot 2024-01-10 at 12 16 48](https://github.com/georgboehm/AudioDino/assets/40793613/1f3be22d-4674-4495-a2c6-f19d25ef2c7b)

Next up:

- Find ways to generate one-time-use non-sketchy download links or tokens
- Create example track
- Start audio track playing loop when game starts and continue to play until game ends
