### PR TITLE
Disallow perma jumping

### DIFF
--- a/public/game.js
+++ b/public/game.js
@@ -46,7 +46,11 @@ class Game {
 
   handleInput() {
     // Key was pressed to make dino jump
-    if (this.gameState == gameStates.PLAYING && !this.dino.isJumping) {
+    if (
+      this.gameState == gameStates.PLAYING &&
+      !this.dino.isJumping &&
+      !this.dino.isFalling
+    ) {
       this.dino.jump();
     }
     // Key was pressed to start new game


### PR DESCRIPTION
You can still hold a button to jump right again when hitting the ground but previously you could jump again on the first falling frame, so technically just stay in the air forever.

Soon: More clever state management since we will probably have a bunch of player states to manage.